### PR TITLE
testing updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 venv/
 *.egg
 *.egg-info/
+.cache
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+
+env:
+  - TOXENV=flake8
+  - TOXENV=py3flake8
+  - TOXENV=py26
+  - TOXENV=py27
+  - TOXENV=py33
+  - TOXENV=py34
+
+install: pip install tox
+
+script: tox

--- a/redis_hashring/__init__.py
+++ b/redis_hashring/__init__.py
@@ -199,10 +199,12 @@ class RingNode(object):
         pipeline = self.conn.pipeline()
         now = time.time()
         for replica in self.replicas:
-            pipeline.zadd(self.key, '{start}:{name}'.format(
-                start=replica[0],
-                name=replica[1]
-            ), now)
+            # for redis >=2.4, the signature is key, score, name
+            pipeline.zadd(
+                self.key,
+                now,
+                '{start}:{name}'.format(start=replica[0], name=replica[1])
+            )
         ret = pipeline.execute()
 
         # Only notify the other nodes if we're not in the ring yet.

--- a/redis_hashring/__init__.py
+++ b/redis_hashring/__init__.py
@@ -137,14 +137,14 @@ class RingNode(object):
 
         ring = self._fetch_all()
 
-        print 'Hash ring "{key}" replicas:'.format(key=self.key)
+        print('Hash ring "{key}" replicas:'.format(key=self.key))
 
         now = time.time()
         n_replicas = len(ring)
         if ring:
-            print '{:10} {:6} {:7} {}'.format('Start', 'Range', 'Delay', 'Node')
+            print('{:10} {:6} {:7} {}'.format('Start', 'Range', 'Delay', 'Node'))
         else:
-            print '(no replicas)'
+            print('(no replicas)')
 
         nodes = collections.defaultdict(list)
 
@@ -158,21 +158,21 @@ class RingNode(object):
 
             nodes[node].append((hostname, pid, abs_size, delay, expired))
 
-            print '{start:10} {size:5.2f}% {delay:6}s {replica}{extra}'.format(
+            print('{start:10} {size:5.2f}% {delay:6}s {replica}{extra}'.format(
                 start=start,
                 replica=replica,
                 delay=delay,
                 size=size,
                 extra=' (EXPIRED)' if expired else ''
-            )
+            ))
 
-        print
-        print 'Hash ring "{key}" nodes:'.format(key=self.key)
+        print()
+        print('Hash ring "{key}" nodes:'.format(key=self.key))
 
         if nodes:
-            print '{:8} {:8} {:7} {:20} {:5}'.format('Range', 'Replicas', 'Delay', 'Hostname', 'PID')
+            print('{:8} {:8} {:7} {:20} {:5}'.format('Range', 'Replicas', 'Delay', 'Hostname', 'PID'))
         else:
-            print '(no nodes)'
+            print('(no nodes)')
 
         for k, v in nodes.items():
             hostname, pid = v[0][0], v[0][1]
@@ -181,7 +181,7 @@ class RingNode(object):
             delay = max(replica[3] for replica in v)
             expired = any(replica[4] for replica in v)
             count = len(v)
-            print '{size:5.2f}% {count:8} {delay:6}s {hostname:20} {pid:5}{extra}'.format(
+            print('{size:5.2f}% {count:8} {delay:6}s {hostname:20} {pid:5}{extra}'.format(
                 start=start,
                 count=count,
                 hostname=hostname,
@@ -189,7 +189,7 @@ class RingNode(object):
                 delay=delay,
                 size=size,
                 extra=' (EXPIRED)' if expired else ''
-            )
+            ))
 
     def heartbeat(self):
         """
@@ -298,7 +298,7 @@ class RingNode(object):
             timeout = max(0, POLL_INTERVAL - (time.time() - last_heartbeat))
             r, w, x = self._select([fileno], [], [], timeout)
             if fileno in r:
-                message = gen.next()
+                gen.next()
                 self.update()
 
             last_heartbeat = time.time()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     license='MIT',
     description='Python library for distributed applications using a Redis hash ring',
     test_suite='tests',
-    tests_require=['redis'],
+    install_requires=['redis>=2.4.0'],
     platforms='any',
     classifiers=[
         'Intended Audience :: Developers',

--- a/tests.py
+++ b/tests.py
@@ -1,8 +1,7 @@
-import unittest
 
 from mock import Mock
 import pytest
-from redis import Redis
+from redis import StrictRedis
 from fakeredis import FakeStrictRedis
 
 
@@ -13,7 +12,7 @@ TEST_KEY = 'hashring-test'
 
 class TestHashRingFunctional(object):
 
-    def tearDown(self):
+    def teardown(self):
         self.redis.delete(TEST_KEY)
 
     def get_node(self, n_replicas, total_replicas):
@@ -47,7 +46,7 @@ class TestHashRingFunctional(object):
 
     @pytest.mark.requires_redis_server
     def test_with_redis_server(self):
-        self.redis = Redis()
+        self.redis = StrictRedis()
         self.ring_assertions()
 
     def test_with_fake_redis_server(self, monkeypatch):

--- a/tests.py
+++ b/tests.py
@@ -1,45 +1,59 @@
 import unittest
 
+from mock import Mock
 import pytest
 from redis import Redis
+from fakeredis import FakeStrictRedis
+
 
 from redis_hashring import RingNode
 
 TEST_KEY = 'hashring-test'
 
 
-@pytest.mark.requires_redis_server
-class HashRingTestCase(unittest.TestCase):
+class TestHashRingFunctional(object):
 
-    def setUp(self):
-        self.redis = Redis()
+    def tearDown(self):
         self.redis.delete(TEST_KEY)
 
     def get_node(self, n_replicas, total_replicas):
         node = RingNode(self.redis, TEST_KEY, n_replicas=n_replicas)
 
-        self.assertEqual(len(node.replicas), n_replicas)
-        self.assertEqual(self.redis.zcard(TEST_KEY), total_replicas-n_replicas)
+        assert len(node.replicas) == n_replicas
+        assert self.redis.zcard(TEST_KEY) == total_replicas-n_replicas
 
         node.heartbeat()
 
-        self.assertEqual(self.redis.zcard(TEST_KEY), total_replicas)
-        self.assertEqual(len(node.ranges), 0)
+        assert self.redis.zcard(TEST_KEY) == total_replicas
+        assert len(node.ranges) == 0
 
         return node
 
-    def test_node(self):
+    def ring_assertions(self):
         node1 = self.get_node(1, 1)
         node1.update()
-        self.assertEqual(len(node1.ranges), 1)
+        assert len(node1.ranges) == 1
 
         node2 = self.get_node(1, 2)
         node1.update()
         node2.update()
-        self.assertEqual(len(node1.ranges) + len(node2.ranges), 3)
+        assert len(node1.ranges) + len(node2.ranges) == 3
 
         node3 = self.get_node(2, 4)
         node1.update()
         node2.update()
         node3.update()
-        self.assertEqual(len(node1.ranges) + len(node2.ranges) + len(node3.ranges), 5)
+        assert len(node1.ranges) + len(node2.ranges) + len(node3.ranges) == 5
+
+    @pytest.mark.requires_redis_server
+    def test_with_redis_server(self):
+        self.redis = Redis()
+        self.ring_assertions()
+
+    def test_with_fake_redis_server(self, monkeypatch):
+        self.redis = FakeStrictRedis()
+
+        # mock publish, since fakeredis doesn't support
+        self.redis.publish = Mock()
+
+        self.ring_assertions()

--- a/tests.py
+++ b/tests.py
@@ -1,10 +1,16 @@
-from redis import Redis
 import unittest
+
+import pytest
+from redis import Redis
+
 from redis_hashring import RingNode
 
 TEST_KEY = 'hashring-test'
 
+
+@pytest.mark.requires_redis_server
 class HashRingTestCase(unittest.TestCase):
+
     def setUp(self):
         self.redis = Redis()
         self.redis.delete(TEST_KEY)

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
      mock
      pretend
      pytest
-     redis
+     fakeredis
 commands = py.test -vv -m "not requires_redis_server" tests.py
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -14,14 +14,12 @@ commands = py.test -vv -m "not requires_redis_server" tests.py
 basepython = python2.7
 deps =
       flake8
-      git+https://github.com/qwcode/qwcore#egg=qwcore
 commands = flake8 .
 
 [testenv:py3flake8]
 basepython = python3.3
 deps =
       flake8
-      git+https://github.com/qwcode/qwcore#egg=qwcore
 commands = flake8 .
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,30 @@
+[tox]
+envlist =
+    flake8,py3flake8,py26,py27,py33,py34
+
+[testenv]
+deps =
+     mock
+     pretend
+     pytest
+     redis
+commands = py.test -vv -m "not requires_redis_server" tests.py
+
+[testenv:flake8]
+basepython = python2.7
+deps =
+      flake8
+      git+https://github.com/qwcode/qwcore#egg=qwcore
+commands = flake8 .
+
+[testenv:py3flake8]
+basepython = python3.3
+deps =
+      flake8
+      git+https://github.com/qwcode/qwcore#egg=qwcore
+commands = flake8 .
+
+[flake8]
+exclude = .tox,*.egg,build,docs
+max-line-length = 120
+ignore =


### PR DESCRIPTION
not necessarily a serious PR, mostly done as a talking point for call with @philfreo

includes the following:
- adds boilerplate for pytest, tox, and travis
- uses the `fakeredis` test library to add a test that can run w/o the redis server being installed
- keeps the old test, but marks it so it doesn't run by default
- uses the `StrictRedis` client class for clarity/consistency with the core Redis API
- py3 compatibility (this could be simpler if `decode_responses` kwarg was used for the redis connection, so responses are always strings, but `fakeredis` doesn't support it at the moment: https://github.com/jamesls/fakeredis/issues/77 )
- adds the `redis` requirement to `install_requires` (and removes from `tests_require`) since it's a run-time requirement

successful travis build is here:  https://travis-ci.org/qwcode/redis-hashring/builds/82463839

also passed locally using a redis server
