### PR TITLE
Drop future import

### DIFF
--- a/redis_hashring/__init__.py
+++ b/redis_hashring/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import binascii
 import collections
 import socket


### PR DESCRIPTION
Since we dropped support for Python 2, we don't need this anymore.