### PR TITLE
Bump to v0.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='redis-hashring',
-    version='0.2.0',
+    version='0.3.0',
     author='Close Engineering',
     author_email='engineering@close.com',
     url='http://github.com/closeio/redis-hashring',


### PR DESCRIPTION
https://github.com/closeio/redis-hashring/commit/fac59d42743eb9f3a92f24cb661bc15e41827a7b introduces a breaking change (you can't use this package with `gevent` if you don't monkey-patch your process).