### PR TITLE
Support unpatched processes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,17 +173,9 @@ gevent example
 greenlet that initializes the ring and periodically updates the node's
 replicas.
 
-To use with ``gevent``, make sure to have called ``gevent.monkey.patch_all()``
-*before* importing ``redis`` and ``redis-hashring`` for the first time in the
-process.
-
 An example app could look as follows:
 
 .. code:: python
-
-  import gevent.monkey
-
-  gevent.monkey.patch_all()
 
   from redis import Redis
   from redis_hashring import RingNode

--- a/redis_hashring/__init__.py
+++ b/redis_hashring/__init__.py
@@ -5,6 +5,7 @@ import time
 import random
 import operator
 import os
+import select
 
 # Amount of points on the ring. Must not be higher than 2**32 because we're
 # using CRC32 to compute the checksum.
@@ -87,6 +88,8 @@ class RingNode(object):
         # List of tuples of ranges this node is responsible for, where a tuple
         # (a, b) includes any N matching a <= N < b.
         self.ranges = []
+
+        self._select = select.select
 
     def _fetch(self):
         """
@@ -306,6 +309,9 @@ class RingNode(object):
         pubsub = self.conn.pubsub()
         pubsub.subscribe(self.key)
 
+        # Pubsub messages generator
+        gen = pubsub.listen()
+
         last_heartbeat = time.time()
         self.heartbeat()
 
@@ -314,14 +320,13 @@ class RingNode(object):
 
         try:
             while True:
+                # Since Redis' listen method blocks, we use select to inspect the
+                # underlying socket to see if there is activity.
+                fileno = pubsub.connection._sock.fileno()
                 timeout = max(0, POLL_INTERVAL - (time.time() - last_heartbeat))
-                message = pubsub.get_message(
-                    ignore_subscribe_messages=True, timeout=timeout
-                )
-                if message:
-                    # Pull remaining messages off of channel.
-                    while pubsub.get_message():
-                        pass
+                r, w, x = self._select([fileno], [], [], timeout)
+                if fileno in r:
+                    next(gen)
                     self.update()
 
                 last_heartbeat = time.time()
@@ -339,8 +344,10 @@ class RingNode(object):
         Helper method to start the node for gevent-based applications.
         """
         import gevent
+        import gevent.select
 
         self._poller_greenlet = gevent.spawn(self.poll)
+        self._select = gevent.select.select
         self.heartbeat()
         self.update()
 
@@ -352,3 +359,4 @@ class RingNode(object):
 
         gevent.kill(self._poller_greenlet)
         self.remove()
+        self._select = select.select


### PR DESCRIPTION
Add back support for `redis-hashring` to run using a greenlet in an unpatched process. This is basically just reverting the relevant bits of https://github.com/closeio/redis-hashring/pull/3.