### PR TITLE
Implement support for unpatched processes with select

### DIFF
--- a/redis_hashring/__init__.py
+++ b/redis_hashring/__init__.py
@@ -5,6 +5,7 @@ import time
 import random
 import operator
 import os
+import select
 
 # Amount of points on the ring. Must not be higher than 2**32 because we're
 # using CRC32 to compute the checksum.
@@ -87,6 +88,8 @@ class RingNode(object):
         # List of tuples of ranges this node is responsible for, where a tuple
         # (a, b) includes any N matching a <= N < b.
         self.ranges = []
+
+        self._select = select.select
 
     def _fetch(self):
         """
@@ -293,7 +296,7 @@ class RingNode(object):
                 return True
         return False
 
-    def poll(self, as_greenlet=False):
+    def poll(self):
         """
         Main loop which maintains the node in the hash ring. Can be run in a
         greenlet or separate thread. This takes care of:
@@ -304,13 +307,10 @@ class RingNode(object):
         """
 
         pubsub = self.conn.pubsub()
-        if as_greenlet:
-            import gevent.socket
-            pubsub.connection._sock = gevent.socket.socket(
-                fileno=pubsub.connection._sock.fileno()
-            )
-
         pubsub.subscribe(self.key)
+
+        # Pubsub messages generator
+        gen = pubsub.listen()
 
         last_heartbeat = time.time()
         self.heartbeat()
@@ -320,14 +320,13 @@ class RingNode(object):
 
         try:
             while True:
+                # Since Redis' listen method blocks, we use select to inspect the
+                # underlying socket to see if there is activity.
+                fileno = pubsub.connection._sock.fileno()
                 timeout = max(0, POLL_INTERVAL - (time.time() - last_heartbeat))
-                message = pubsub.get_message(
-                    ignore_subscribe_messages=True, timeout=timeout
-                )
-                if message:
-                    # Pull remaining messages off of channel.
-                    while pubsub.get_message():
-                        pass
+                r, w, x = self._select([fileno], [], [], timeout)
+                if fileno in r:
+                    next(gen)
                     self.update()
 
                 last_heartbeat = time.time()
@@ -345,8 +344,10 @@ class RingNode(object):
         Helper method to start the node for gevent-based applications.
         """
         import gevent
+        import gevent.select
 
-        self._poller_greenlet = gevent.spawn(self.poll, as_greenlet=True)
+        self._poller_greenlet = gevent.spawn(self.poll)
+        self._select = gevent.select.select
         self.heartbeat()
         self.update()
 
@@ -358,3 +359,4 @@ class RingNode(object):
 
         gevent.kill(self._poller_greenlet)
         self.remove()
+        self._select = select.select

--- a/redis_hashring/__init__.py
+++ b/redis_hashring/__init__.py
@@ -344,8 +344,8 @@ class RingNode(object):
         import gevent
         import gevent.select
 
-        self._poller_greenlet = gevent.spawn(self.poll)
         self._select = gevent.select.select
+        self._poller_greenlet = gevent.spawn(self.poll)
         self.heartbeat()
         self.update()
 

--- a/redis_hashring/__init__.py
+++ b/redis_hashring/__init__.py
@@ -309,9 +309,6 @@ class RingNode(object):
         pubsub = self.conn.pubsub()
         pubsub.subscribe(self.key)
 
-        # Pubsub messages generator
-        gen = pubsub.listen()
-
         last_heartbeat = time.time()
         self.heartbeat()
 
@@ -326,7 +323,8 @@ class RingNode(object):
                 timeout = max(0, POLL_INTERVAL - (time.time() - last_heartbeat))
                 r, w, x = self._select([fileno], [], [], timeout)
                 if fileno in r:
-                    next(gen)
+                    while pubsub.get_message():
+                        pass
                     self.update()
 
                 last_heartbeat = time.time()


### PR DESCRIPTION
When I shipped `v0.3.1` to production, I found out that `pubsub.connection is None` when `pubsub` has just been created. It is created upon the first command issued. The solution is to force the creation of a connection at that time by calling directly into the connection pool, and then continue to patch the underlying socket. However, that is not what this PR is doing. Plot twist!

After doing that, I found out that, for some reason, `gevent.socket.recv` doesn't yield control to the event loop when we would expect it to. I tried to investigate it for some time but I came to the conclusion that it can take longer than I can afford to get to the bottom of why `gevent.socket` is not yielding.

So I decided to submit this PR, which is the original implementation with `gevent.select`, which we know works. (And I re-tested it, even if just for sanity sake.)