### PR TITLE
Allow `poll` to end cleanly

### DIFF
--- a/redis_hashring/__init__.py
+++ b/redis_hashring/__init__.py
@@ -341,6 +341,8 @@ class RingNode(object):
                 timeout = max(0, POLL_INTERVAL - (time.time() - last_heartbeat))
                 r, w, x = self._select([self._stop_polling_fd_r, pubsub_fd], [], [], timeout)
                 if self._stop_polling_fd_r in r:
+                    os.close(self._stop_polling_fd_r)
+                    os.close(self._stop_polling_fd_w)
                     self._stop_polling_fd_r = None
                     self._stop_polling_fd_w = None
                     break


### PR DESCRIPTION
Before, the `poll` function wouldn't end cleanly: you needed to [kill it](https://github.com/closeio/redis-hashring/blob/master/redis_hashring/__init__.py#L358). That works for gevent coroutines, but you can't kill OS threads. You need to call `join` on them and wait for them to die.

This PR enables that, and also adds helper methods `start` and `stop` for thread-based applications to use. This interface is similar to the one we already have for gevent.