### PR TITLE
Release 0.3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='redis-hashring',
-    version='0.3.3',
+    version='0.3.4',
     author='Close Engineering',
     author_email='engineering@close.com',
     url='http://github.com/closeio/redis-hashring',


### PR DESCRIPTION
Includes https://github.com/closeio/redis-hashring/pull/22.