### PR TITLE
Release 0.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="redis-hashring",
-    version="0.4.0",
+    version="0.5.0",
     author="Close Engineering",
     author_email="engineering@close.com",
     url="https://github.com/closeio/redis-hashring",


### PR DESCRIPTION
New features:

- `RingNode` now may be used as a context manager.
- `GeventRingNode` is introduced as a subclass of `RingNode` that uses greenlets instead of threads to manage node and ring state.

Breaking changes:

- Logic to manage state with greenlets was extracted into `GeventRingNode`.
  - `RingNode.gevent_start` is now `GeventRingNode.start`.
  - `RingNode.gevent_stop` is now `GeventRingNode.stop`.