### PR TITLE
Drop support for EOL Python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,6 @@ workflows:
   workflow:
     jobs:
       - lint
-      - test-3.8
-      - test-3.9
       - test-3.10
       - test-3.11
       - test-3.12
@@ -44,16 +42,6 @@ jobs:
         command: |
           export PATH=$HOME/.local/bin:$PATH
           ruff check --no-cache
-  test-3.8:
-    <<: *defaults
-    docker:
-    - image: python:3.8
-    - image: redis:7.2.4
-  test-3.9:
-    <<: *defaults
-    docker:
-    - image: python:3.9
-    - image: redis:7.2.4
   test-3.10:
     <<: *defaults
     docker:


### PR DESCRIPTION
Python 3.8 is dead, and Python 3.9 is dying in two months.

https://devguide.python.org/versions/